### PR TITLE
Added dynamic region retrieval, API based tag filtering and list_all_tagged_nodes.ps1.

### DIFF
--- a/Scripts/list_all_tagged_nodes.ps1
+++ b/Scripts/list_all_tagged_nodes.ps1
@@ -1,5 +1,5 @@
-# stop_all_tagged_nodes.ps1 - Stops all the instances that match a specific tag, in all AWS regions
-# Eg: stop_all_tagged_nodes.ps1 -tag isLatencyCollector -accessKeyID AKI******** -secretAccessKeyID 1VVllumsz*** 
+# list_all_tagged_nodes.ps1 - Lists all the instances that match a specific tag, in all AWS regions
+# Eg: list_all_tagged_nodes.ps1 -tag isLatencyCollector -accessKeyID AKI******** -secretAccessKeyID 1VVllumsz*** 
 Param(
 	[parameter(mandatory=$true, HelpMessage="Enter your AWS access key.")]
 	[String]
@@ -35,18 +35,12 @@ foreach($region in $regions) {
 	}
 	$response = $client.DescribeInstances($request)
 
-	$stopInstanceRequest = New-Object —TypeName Amazon.EC2.Model.StopInstancesRequest
-	$stopInstanceRequest.InstanceId = New-Object System.Collections.Generic.List``1[System.String]
+	$startInstanceRequest = New-Object —TypeName Amazon.EC2.Model.StartInstancesRequest
+	$startInstanceRequest.InstanceId = New-Object System.Collections.Generic.List``1[System.String]
 
 	foreach($reservation in $response.DescribeInstancesResult.Reservation) {
-		foreach($instance in $reservation.RunningInstance) { 
-			Write-Host "Queueing instance" $instance.InstanceId "for stopping..."
-			$stopInstanceRequest.InstanceId.Add($instance.InstanceId)
-		}
+	  foreach($instance in $reservation.RunningInstance) { 
+		Write-Host "Matching instance" $instance.InstanceId
+	  }
 	}
-
-	Write-Host "Stopping" $stopInstanceRequest.InstanceId.Count "instances in:" $region.RegionName
-
-	$stopInstanceResponse = $client.StopInstances($stopInstanceRequest)
-	$stopInstanceResponse.ToString()
 }

--- a/Scripts/stop_start_tagged_nodes.md
+++ b/Scripts/stop_start_tagged_nodes.md
@@ -1,13 +1,13 @@
-Stop/start collection of Amazon instances based on tag
+Stop/start collection of Amazon EC2 instances based on tag
 ======================================================
 
-These scripts can be used to quickly stop or start a group of AWS instances based
+These scripts can be used to quickly list, stop or start a group of AWS instances based
 on an instance tag.
 
 For example, say you needed to quickly stop all the instances that were running 
 the CIAPI Latency Collector service.  From a PowerShell command prompt you would run:
 
-PS > stop_all_tagged_nodes.ps1 --access_key="AWS-access-key" --secret_access_key="AWS-secret" --tag="CIAPILatencyCollector"
+PS > stop_all_tagged_nodes.ps1 -access_key="AWS-access-key" -secret_access_key="AWS-secret" -tag="CIAPILatencyCollector"
 
 Installation
 ============
@@ -39,5 +39,6 @@ Installation
 Running
 =======
 
+1.  To list ```list_all_tagged_nodes.ps1 -tag isLatencyCollector -accessKeyID AKI******** -secretAccessKeyID 1VVllumsz*** ```
 1.  To stop ```stop_all_tagged_nodes.ps1 -tag isLatencyCollector -accessKeyID AKI******** -secretAccessKeyID 1VVllumsz*** ```
 1.  To start ```start_all_tagged_nodes.ps1 -tag isLatencyCollector -accessKeyID AKI******** -secretAccessKeyID 1VVllumsz*** ```


### PR DESCRIPTION
To get into AWS usage via PowerShell some more I've adjusted the following aspects:
- added dynamic region retrieval
- replaced client side tag filtering with API based tag  filtering
  - the AWS API provides filters for most describe*() methods, which can be used to reduce the retrieved resources API side already, and offers versatile filter combinations as well - see [Listing and Filtering Your Resources](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/Using_Filtering.html) for details
  - the more flexible approach would accordingly be to allow specification of the entire filter as an argument, but for he use case at hand the simple tag name variation seems more appropriate (an optional value rather than the hardcoded '*' would add some flexibility of course)
- added list_all_tagged_nodes.ps1 to test/experiment with the filtering
- fixed *.InstanceId.Count printing
