### PR TITLE
(Manually) Publish weekly CIAPI performance graphs to labs.cityindex.com/performance blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ _package/
 
 ~$*
 _reports/*
+.Rproj.user

--- a/Reports/RStudio/.gitignore
+++ b/Reports/RStudio/.gitignore
@@ -1,0 +1,2 @@
+.Rhistory
+.RData

--- a/Reports/RStudio/AppMetrics.Rproj
+++ b/Reports/RStudio/AppMetrics.Rproj
@@ -1,0 +1,14 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+RootDocument: 

--- a/Reports/RStudio/client_side_latency.Rmd
+++ b/Reports/RStudio/client_side_latency.Rmd
@@ -9,8 +9,8 @@ metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
 
 ```{r fetchData0, echo=FALSE}
 application <- "CIAPILatencyCollector" 
-startTime <- "2012-09-04 13:00:00"
-endTime <- "2012-09-10 23:59:59"
+startTime <- "2012-09-11 13:00:00"
+endTime <- "2012-09-17 23:59:59"
 data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
@@ -20,14 +20,11 @@ colnames(logdata)=c('session','timestamp','key','value')
 ```
 
 ```{r groupSessionByNodes0, echo=FALSE}
-nodes <- logdata[logdata$"key" %in% c("Info_NodeName"), ]
+nodes1 <- logdata[logdata$"key" %in% c("Info_NodeName"), ]
 
-#temp bugfix - this session doesn't seem to report a ClientIP
-nodes[3,] <- c("39d948e7-5f2c-4b24-995e-94f1f6c3eab6", "2012-09-03 13:45:42.5018590", "NodeName", "AWS-EU-WEST-1B-79.125.25.36")
+nodes1$nodeName = nodes1$value
 
-nodes$nodeName = nodes$value
-
-nodes <- subset(nodes, select=c(-timestamp,-key,-value))
+nodes1 <- subset(nodes1, select=c(-timestamp,-key,-value))
 ```
 
 Latency between different endpoints
@@ -38,7 +35,7 @@ measures the latency due to the network:
 ```{r network_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
 rpc <- logdata[logdata$"key" %in% c("Latency General.DefaultPage"), ]
 rpc$datetime <- strptime(rpc$timestamp, "%Y-%m-%d %H:%M:%S")
-rpc <- join(rpc, nodes, by = "session", match = "first")
+rpc <- join(rpc, nodes1, by = "session", match = "first")
 
 d <- ggplot(rpc, aes(x=datetime, y=as.double(value)))
 d <- d + scale_y_continuous(limits=c(0.001, 1))
@@ -51,12 +48,10 @@ print(d)
 ```
 As is expected, both the latency measures and the variability is higher for nodes geographically further away.
 
-The collection nodes currently have a memory leak issue that causes periodic failure to collect data (hence the gaps.)  This will be addressed in the next release.
-
 ```{r fetchData, echo=FALSE}
 application <- "CIAPILatencyCollector.AllServiceMonitor.BuiltIn" #will switch to CIAPILatencyCollector once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
-startTime <- "2012-09-04 13:00:00"
-endTime <- "2012-09-10 23:59:59"
+startTime <- "2012-09-11 13:00:00"
+endTime <- "2012-09-17 23:59:59"
 data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
@@ -83,11 +78,8 @@ logdata$key <- sub('Latency CIAPI.order/newtradeorder', 'Latency CIAPI.Trade',lo
 ```{r groupSessionByNodes, echo=FALSE}
 nodes <- logdata[logdata$"key" %in% c("ClientIP"), ]
 
-#temp bugfix - this session doesn't seem to report a ClientIP
-nodes[2,] <- c("39d948e7-5f2c-4b24-995e-94f1f6c3eab6", "2012-09-03 13:45:42.5018590", "ClientIP", "AWS-EU-WEST-1B-79.125.25.36")
-
 nodes$nodeName = nodes$value
-nodes$nodeName <- sub('46.137.47.103', 'AWS-EU-WEST-1B-79.125.25.36',nodes$nodeName, fixed = TRUE)
+nodes$nodeName <- sub('46.137.47.103', 'AWS-EU-WEST-1B-79.125.25.36', nodes$nodeName, fixed = TRUE)
 
 nodes <- subset(nodes, select=c(-timestamp,-key,-value))
 ```
@@ -124,10 +116,7 @@ d <- d + facet_grid(key ~ nodeName)
 d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
-
-Latencies for different services are pretty similar, with the median being around 100ms and the 98th percentile being sub 300ms.
-
-Its noticable that those services which transfer more data - ListSpreadMarkets, ListTradeHistory - are 3 times slower that those that transfer very little data - Login, Trade, etc
+There appears to have been some downtime on Sept 15th and 16th with the ListOpenPositions & ListTradeHistory services.
 
 Selective latencies in depth
 -----------------------------------
@@ -161,12 +150,8 @@ d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
 
-Since the last report a new release of the TradingAPI webserver component has been deployed, and as in the PPE environment we see a dramatic decrease in "low data" services like GetClientTradingAccount, Trade and Login median latency - from around 300ms to sub 100ms.
+Performance has been largly consistent, with median Trade andLogin requests where processed in 100ms.
 
-98% of Trade, GetClientTradingAccount and Login requests where processed within 300ms.
-
-Something unusual happened to the ListTradeHistory latency on 6th and again on the 8th.  At a guess, the amount of data transfered was probably dramatically reduced, perhaps due to some downtime on the backend service supplying the data.
-
-Finally, we still see quite a few outliers for the Trade and Login services, with some requests taking up to 10 seconds to process. 
+Finally, we continue to see quite a few outliers for the Trade and Login services, with some requests taking up to 10 seconds to process. 
 
 

--- a/Reports/RStudio/client_side_latency.Rmd
+++ b/Reports/RStudio/client_side_latency.Rmd
@@ -7,10 +7,10 @@ readRenviron("~/.Renviron") # Make sure you have a APPMETRICS_CREDENTIALS=userna
 metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
 ```
 
-```{r fetchData, echo=FALSE}
-application <- "CIAPILatencyCollector" #.AllServiceMonitor.BuiltIn will switch to CIAPILatencyCollector once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
-startTime <- "2012-08-17 00:00:00"
-endTime <- "2012-08-24 23:59:59"
+```{r fetchData0, echo=FALSE}
+application <- "CIAPILatencyCollector" 
+startTime <- "2012-09-04 13:00:00"
+endTime <- "2012-09-10 23:59:59"
 data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
@@ -19,29 +19,14 @@ close(tc)
 colnames(logdata)=c('session','timestamp','key','value')
 ```
 
-```{r convert_to_CIAPILatencyCollector_names, echo=FALSE}
-# Temporary measure to convert CIAPILatencyCollector.AllServiceMonitor.BuiltIn names to CIAPILatencyCollector names.  Will not be needed once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
-logdata$key <- sub('Latency https://ciapi.cityindex.com/TradingApi/', 'Latency CIAPI.',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.session/deleteSession', 'Latency CIAPI.LogOut',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.session', 'Latency CIAPI.LogIn',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.spread/markets?MarketName=&MarketCode=&ClientAccountId=400194351&MaxResults=100&UseMobileShortName=False', 'Latency CIAPI.ListSpreadMarkets',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.useraccount/ClientAndTradingAccount', 'Latency CIAPI.GetClientAndTradingAccount',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.market/400616150/information', 'Latency CIAPI.GetMarketInformation',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.market/400616150/barhistory?interval=MINUTE&span=1&PriceBars=20', 'Latency CIAPI.GetPriceBars',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.order/order/openpositions?TradingAccountId=400290710', 'Latency CIAPI.ListOpenPositions',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.news/dj/UK?MaxResults=10', 'Latency CIAPI.ListNewsHeadlinesWithSource',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.order/order/tradehistory?TradingAccountId=400290710&MaxResults=20', 'Latency CIAPI.ListTradeHistory',logdata$key, fixed = TRUE)
-logdata$key <- sub('Latency CIAPI.order/newtradeorder', 'Latency CIAPI.Trade',logdata$key, fixed = TRUE)
-```
+```{r groupSessionByNodes0, echo=FALSE}
+nodes <- logdata[logdata$"key" %in% c("Info_NodeName"), ]
 
-```{r groupSessionByNodes, echo=FALSE}
-# 46.137.47.103  => Production Ireland CIAPI Latency Collector node      (switched to 79.125.25.36  on 2012-09-03)
-# 175.41.155.112 => Production Singapore CIAPI Latency Collector node   (switched to 54.251.61.159 on 2012-09-03)
+#temp bugfix - this session doesn't seem to report a ClientIP
+nodes[3,] <- c("39d948e7-5f2c-4b24-995e-94f1f6c3eab6", "2012-09-03 13:45:42.5018590", "NodeName", "AWS-EU-WEST-1B-79.125.25.36")
 
-nodes <- logdata[logdata$"key" %in% c("ClientIP"), ]
 nodes$nodeName = nodes$value
-nodes$nodeName <- sub('46.137.47.103', 'AWS_Ireland(46.137.47.103)',nodes$nodeName, fixed = TRUE)
-nodes$nodeName <- sub('175.41.155.112', 'AWS_Singapore(175.41.155.112)',nodes$nodeName, fixed = TRUE)
+
 nodes <- subset(nodes, select=c(-timestamp,-key,-value))
 ```
 
@@ -66,7 +51,47 @@ print(d)
 ```
 As is expected, both the latency measures and the variability is higher for nodes geographically further away.
 
-It appears that there was a network connectivity issue between the CIAPI and the Ireland node on Aug 19th.
+The collection nodes currently have a memory leak issue that causes periodic failure to collect data (hence the gaps.)  This will be addressed in the next release.
+
+```{r fetchData, echo=FALSE}
+application <- "CIAPILatencyCollector.AllServiceMonitor.BuiltIn" #will switch to CIAPILatencyCollector once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
+startTime <- "2012-09-04 13:00:00"
+endTime <- "2012-09-10 23:59:59"
+data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
+
+webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
+logdata <- read.table(tc <- textConnection(webpage), header=F, sep="\t", fill=TRUE, as.is=c(1,4)); 
+close(tc)
+colnames(logdata)=c('session','timestamp','key','value')
+```
+
+```{r convert_to_CIAPILatencyCollector_names, echo=FALSE}
+# Temporary measure to convert CIAPILatencyCollector.AllServiceMonitor.BuiltIn names to CIAPILatencyCollector names.  Will not be needed once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
+logdata$key <- sub('Latency https://ciapi.cityindex.com/TradingApi/', 'Latency CIAPI.',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.session/deleteSession', 'Latency CIAPI.LogOut',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.session', 'Latency CIAPI.LogIn',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.spread/markets?MarketName=&MarketCode=&ClientAccountId=400194351&MaxResults=100&UseMobileShortName=False', 'Latency CIAPI.ListSpreadMarkets',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.useraccount/UserAccount/ClientAndTradingAccount', 'Latency CIAPI.GetClientAndTradingAccount',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.market/400616150/information', 'Latency CIAPI.GetMarketInformation',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.market/400616150/barhistory?interval=MINUTE&span=1&PriceBars=20', 'Latency CIAPI.GetPriceBars',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.order/order/openpositions?TradingAccountId=400290710', 'Latency CIAPI.ListOpenPositions',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.news/dj/UK?MaxResults=10', 'Latency CIAPI.ListNewsHeadlinesWithSource',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.order/order/tradehistory?TradingAccountId=400290710&MaxResults=20', 'Latency CIAPI.ListTradeHistory',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.order/newtradeorder', 'Latency CIAPI.Trade',logdata$key, fixed = TRUE)
+```
+
+```{r groupSessionByNodes, echo=FALSE}
+nodes <- logdata[logdata$"key" %in% c("ClientIP"), ]
+
+#temp bugfix - this session doesn't seem to report a ClientIP
+nodes[2,] <- c("39d948e7-5f2c-4b24-995e-94f1f6c3eab6", "2012-09-03 13:45:42.5018590", "ClientIP", "AWS-EU-WEST-1B-79.125.25.36")
+
+nodes$nodeName = nodes$value
+nodes$nodeName <- sub('46.137.47.103', 'AWS-EU-WEST-1B-79.125.25.36',nodes$nodeName, fixed = TRUE)
+
+nodes <- subset(nodes, select=c(-timestamp,-key,-value))
+```
+
 
 Latency between different services
 -----------------------------------
@@ -86,11 +111,11 @@ rpc2 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
 rpc2$datetime <- strptime(rpc2$timestamp, "%Y-%m-%d %H:%M:%S")
 rpc2$key <- sub('Latency CIAPI.', '',rpc2$key)
 rpc2 <- join(rpc2, nodes, by = "session", match = "first")
-rpc2 <- rpc2[rpc2$nodeName %in% c("AWS_Ireland(46.137.47.103)"),]
+rpc2 <- rpc2[rpc2$nodeName %in% c("AWS-EU-WEST-1B-79.125.25.36"),]
 
 d <- ggplot(rpc2, aes(x=datetime, y=as.double(value)))
 d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
-d <- d + scale_y_log10(breaks=c(0.2,0.3,0.6,1.5), limits=c(0.2, 2))
+d <- d + scale_y_log10(breaks=c(0.1,0.3,0.6), limits=c(0.05, 0.7))
 d <- d + geom_hex()
 d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
 d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
@@ -100,7 +125,9 @@ d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
 
-Latencies for different services are pretty similar, with the median being around 300ms and the 98th percentile being around 1 second.
+Latencies for different services are pretty similar, with the median being around 100ms and the 98th percentile being sub 300ms.
+
+Its noticable that those services which transfer more data - ListSpreadMarkets, ListTradeHistory - are 3 times slower that those that transfer very little data - Login, Trade, etc
 
 Selective latencies in depth
 -----------------------------------
@@ -120,24 +147,26 @@ rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
 rpc3$datetime <- strptime(rpc3$timestamp, "%Y-%m-%d %H:%M:%S")
 rpc3$key <- sub('Latency CIAPI.', '',rpc3$key)
 rpc3 <- join(rpc3, nodes, by = "session", match = "first")
-rpc3 <- rpc3[rpc3$nodeName %in% c("AWS_Ireland(46.137.47.103)"),]
+rpc3 <- rpc3[rpc3$nodeName %in% c("AWS-EU-WEST-1B-79.125.25.36"),]
 
 d <- ggplot(rpc3, aes(x=datetime, y=as.double(value)))
 d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
-d <- d + scale_y_log10(breaks=c(0.3,1,10)) 
+d <- d + scale_y_log10() 
 d <- d + geom_hex()
 d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
 d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
 d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
-d <- d + facet_grid(key ~ nodeName)
+d <- d + facet_grid(key ~ nodeName, scales="free_y")
 d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
 
-Both the median and 98th percentile latencies for ListTradeHistory gradually increase; which makes complete sense given that the amount of data transfered increases steadily as more trades are placed.
+Since the last report a new release of the TradingAPI webserver component has been deployed, and as in the PPE environment we see a dramatic decrease in "low data" services like GetClientTradingAccount, Trade and Login median latency - from around 300ms to sub 100ms.
 
-There isn't much difference between the other services - median latency is around 300 ms, with 98% of requests being serviced in less than 1 second.
+98% of Trade, GetClientTradingAccount and Login requests where processed within 300ms.
 
-Login has quite a few outliers, and no trades are placed when markets are closed (18th & 19th Aug is a weekend).
+Something unusual happened to the ListTradeHistory latency on 6th and again on the 8th.  At a guess, the amount of data transfered was probably dramatically reduced, perhaps due to some downtime on the backend service supplying the data.
+
+Finally, we still see quite a few outliers for the Trade and Login services, with some requests taking up to 10 seconds to process. 
 
 

--- a/Reports/RStudio/client_side_latency.Rmd
+++ b/Reports/RStudio/client_side_latency.Rmd
@@ -1,74 +1,143 @@
-CIAPI client side latency - 13 June 2012
-===========================================
 ```{r init, echo=FALSE}
 library("ggplot2")
 library("RCurl")
 library("plyr")
 library("scales")
+readRenviron("~/.Renviron") # Make sure you have a APPMETRICS_CREDENTIALS=username:password entry
 metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
-startTime <- "2012-07-03 13:00:00"
-endTime <- "2012-07-03 14:00:00"
-data_url <- URLencode(paste("http://metrics.labs.cityindex.com/GetRecords.ashx?Application=CIAPILatencyCollector&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 ```
 
 ```{r fetchData, echo=FALSE}
+application <- "CIAPILatencyCollector" #.AllServiceMonitor.BuiltIn will switch to CIAPILatencyCollector once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
+startTime <- "2012-08-17 00:00:00"
+endTime <- "2012-08-24 23:59:59"
+data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
+
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
 logdata <- read.table(tc <- textConnection(webpage), header=F, sep="\t", fill=TRUE, as.is=c(1,4)); 
 close(tc)
 colnames(logdata)=c('session','timestamp','key','value')
 ```
 
+```{r convert_to_CIAPILatencyCollector_names, echo=FALSE}
+# Temporary measure to convert CIAPILatencyCollector.AllServiceMonitor.BuiltIn names to CIAPILatencyCollector names.  Will not be needed once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
+logdata$key <- sub('Latency https://ciapi.cityindex.com/TradingApi/', 'Latency CIAPI.',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.session/deleteSession', 'Latency CIAPI.LogOut',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.session', 'Latency CIAPI.LogIn',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.spread/markets?MarketName=&MarketCode=&ClientAccountId=400194351&MaxResults=100&UseMobileShortName=False', 'Latency CIAPI.ListSpreadMarkets',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.useraccount/ClientAndTradingAccount', 'Latency CIAPI.GetClientAndTradingAccount',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.market/400616150/information', 'Latency CIAPI.GetMarketInformation',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.market/400616150/barhistory?interval=MINUTE&span=1&PriceBars=20', 'Latency CIAPI.GetPriceBars',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.order/order/openpositions?TradingAccountId=400290710', 'Latency CIAPI.ListOpenPositions',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.news/dj/UK?MaxResults=10', 'Latency CIAPI.ListNewsHeadlinesWithSource',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.order/order/tradehistory?TradingAccountId=400290710&MaxResults=20', 'Latency CIAPI.ListTradeHistory',logdata$key, fixed = TRUE)
+logdata$key <- sub('Latency CIAPI.order/newtradeorder', 'Latency CIAPI.Trade',logdata$key, fixed = TRUE)
+```
+
 ```{r groupSessionByNodes, echo=FALSE}
+# 46.137.47.103  => Production Ireland CIAPI Latency Collector node      (switched to 79.125.25.36  on 2012-09-03)
+# 175.41.155.112 => Production Singapore CIAPI Latency Collector node   (switched to 54.251.61.159 on 2012-09-03)
+
 nodes <- logdata[logdata$"key" %in% c("ClientIP"), ]
 nodes$nodeName = nodes$value
+nodes$nodeName <- sub('46.137.47.103', 'AWS_Ireland(46.137.47.103)',nodes$nodeName, fixed = TRUE)
+nodes$nodeName <- sub('175.41.155.112', 'AWS_Singapore(175.41.155.112)',nodes$nodeName, fixed = TRUE)
 nodes <- subset(nodes, select=c(-timestamp,-key,-value))
 ```
+
 Latency between different endpoints
 -----------------------------------
 The following chart compares the latency of the Default IIS page from different 
-endpoints:
-```{r network_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE}
+endpoints.  The IIS default page is assumed to be the fasted response the server can give, so this
+measures the latency due to the network:
+```{r network_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
 rpc <- logdata[logdata$"key" %in% c("Latency General.DefaultPage"), ]
 rpc$datetime <- strptime(rpc$timestamp, "%Y-%m-%d %H:%M:%S")
 rpc <- join(rpc, nodes, by = "session", match = "first")
 
 d <- ggplot(rpc, aes(x=datetime, y=as.double(value)))
-d <- d + scale_y_log10()
+d <- d + scale_y_continuous(limits=c(0.001, 1))
 d <- d + geom_hex()
+d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
+d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
 d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
 d <- d + facet_grid(nodeName ~ key)
 print(d)
 ```
-As is expected, latency is higher for nodes geographically further away.
+As is expected, both the latency measures and the variability is higher for nodes geographically further away.
+
+It appears that there was a network connectivity issue between the CIAPI and the Ireland node on Aug 19th.
 
 Latency between different services
 -----------------------------------
 The following graph compares the latency of different services for the same node:
-```{r service_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE}
-rpc2 <- logdata[logdata$"key" %in% c("Latency General.DefaultPage"
-                                    ,"Latency CIAPI.LogIn"
+```{r service_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
+rpc2 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
                                     ,"Latency CIAPI.LogOut"
-                                    ,"Latency CIAPI.ListCfdMarkets"
+                                    ,"Latency CIAPI.ListSpreadMarkets"
                                     ,"Latency CIAPI.GetClientAndTradingAccount"     
                                     ,"Latency CIAPI.GetMarketInformation"
-                                    ,"Latency CIAPI.ListCfdMarkets"
                                     ,"Latency CIAPI.GetPriceBars"
                                     ,"Latency CIAPI.ListOpenPositions"
                                     ,"Latency CIAPI.ListNewsHeadlinesWithSource"
                                     ,"Latency CIAPI.ListTradeHistory"
                                     ,"Latency CIAPI.Trade" ), ]
+
 rpc2$datetime <- strptime(rpc2$timestamp, "%Y-%m-%d %H:%M:%S")
 rpc2$key <- sub('Latency CIAPI.', '',rpc2$key)
 rpc2 <- join(rpc2, nodes, by = "session", match = "first")
-rpc2 <- rpc2[rpc2$nodeName %in% c("46.137.187.155"),]
+rpc2 <- rpc2[rpc2$nodeName %in% c("AWS_Ireland(46.137.47.103)"),]
 
 d <- ggplot(rpc2, aes(x=datetime, y=as.double(value)))
 d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
-d <- d + scale_y_continuous(limits=c(0,1))
+d <- d + scale_y_log10(breaks=c(0.2,0.3,0.6,1.5), limits=c(0.2, 2))
 d <- d + geom_hex()
+d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
+d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
 d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
-d <- d + facet_grid(key ~ nodeName, margins = c("key"))
+d <- d + facet_grid(key ~ nodeName)
 d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
-As can be seen, blah blah blah
+
+Latencies for different services are pretty similar, with the median being around 300ms and the 98th percentile being around 1 second.
+
+Selective latencies in depth
+-----------------------------------
+The following graph compares:
+
+1. GetClientAndTradingAccount - A "readonly" service query 
+1. ListTradeHistory - A complex "readonly" query
+1. Login - A simple "change server state" query
+1. Trade - A complex "change server state" query
+
+```{r service_latency_plot_in_depth, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
+rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
+                                    ,"Latency CIAPI.GetClientAndTradingAccount"   
+                                    ,"Latency CIAPI.Trade"
+                                    ,"Latency CIAPI.ListTradeHistory"), ]
+
+rpc3$datetime <- strptime(rpc3$timestamp, "%Y-%m-%d %H:%M:%S")
+rpc3$key <- sub('Latency CIAPI.', '',rpc3$key)
+rpc3 <- join(rpc3, nodes, by = "session", match = "first")
+rpc3 <- rpc3[rpc3$nodeName %in% c("AWS_Ireland(46.137.47.103)"),]
+
+d <- ggplot(rpc3, aes(x=datetime, y=as.double(value)))
+d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
+d <- d + scale_y_log10(breaks=c(0.3,1,10)) 
+d <- d + geom_hex()
+d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
+d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
+d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
+d <- d + facet_grid(key ~ nodeName)
+d <- d + opts(strip.text.y = theme_text( angle=0))
+print(d)
+```
+
+Both the median and 98th percentile latencies for ListTradeHistory gradually increase; which makes complete sense given that the amount of data transfered increases steadily as more trades are placed.
+
+There isn't much difference between the other services - median latency is around 300 ms, with 98% of requests being serviced in less than 1 second.
+
+Login has quite a few outliers, and no trades are placed when markets are closed (18th & 19th Aug is a weekend).
+
+

--- a/Reports/RStudio/client_side_latency.Rmd
+++ b/Reports/RStudio/client_side_latency.Rmd
@@ -9,8 +9,8 @@ metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
 
 ```{r fetchData0, echo=FALSE}
 application <- "CIAPILatencyCollector" 
-startTime <- "2012-09-17 13:00:00"
-endTime <- "2012-09-24 23:59:59"
+startTime <- "2012-09-24 13:00:00"
+endTime <- "2012-10-01 23:59:59"
 data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
@@ -23,8 +23,12 @@ colnames(logdata)=c('session','timestamp','key','value')
 nodes1 <- logdata[logdata$"key" %in% c("Info_NodeName"), ]
 
 nodes1$nodeName = nodes1$value
-
 nodes1 <- subset(nodes1, select=c(-timestamp,-key,-value))
+
+#Manually add sessions listed from http://metrics.cityindex.com/GetSessions.ashx
+nodes1[2,] <- c("d92b078a-c509-41cb-83df-ab5d6d136ee8", "AWS-Ireland")
+nodes1[3,] <- c("c037797b-c753-4118-9d69-89ef8d7e4204", "AWS-Singapore")
+
 ```
 
 Latency between different endpoints
@@ -50,8 +54,8 @@ As is expected, both the latency measures and the variability is higher for node
 
 ```{r fetchData, echo=FALSE}
 application <- "CIAPILatencyCollector.AllServiceMonitor.BuiltIn" #will switch to CIAPILatencyCollector once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
-startTime <- "2012-09-17 13:00:00"
-endTime <- "2012-09-24 23:59:59"
+startTime <- "2012-09-24 13:00:00"
+endTime <- "2012-10-01 23:59:59"
 data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
@@ -116,22 +120,19 @@ d <- d + facet_grid(key ~ nodeName)
 d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
-There appears to have been some downtime on Sept 15th and 16th with the ListOpenPositions & ListTradeHistory services.
+Performance has been consistenly good over the past week, with a slight degredation in performance for the ListTradeHistory service between 27th Sept and 29th Sept
 
 Selective latencies in depth
 -----------------------------------
 The following graph compares:
 
-1. GetClientAndTradingAccount - A "readonly" service query 
-1. ListTradeHistory - A complex "readonly" query
 1. Login - A simple "change server state" query
+1. ListTradeHistory - A complex "readonly" query
 1. Trade - A complex "change server state" query
 
 ```{r service_latency_plot_in_depth, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
 rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
-                                    ,"Latency CIAPI.Trade"
-                                    ,"Latency CIAPI.ListSpreadMarkets"
-                                    ,"Latency CIAPI.ListOpenPositions"         
+                                    ,"Latency CIAPI.Trade"         
                                     ,"Latency CIAPI.ListTradeHistory"), ]
 
 rpc3$datetime <- strptime(rpc3$timestamp, "%Y-%m-%d %H:%M:%S")
@@ -151,7 +152,9 @@ d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
 
-Performance has been largly consistent, with median Trade andLogin requests where processed in 100ms.
+Performance has been consistent, with median Trade and Login requests where processed in 100ms.
+
+During the period of performance degredation for the ListTradeHistory service there were also a number of outliers beyond the 1 second latency.
 
 Finally, we continue to see quite a few outliers for the Trade and Login services, with some requests taking up to 10 seconds to process. 
 

--- a/Reports/RStudio/client_side_latency_ListServicesInDetail.Rmd
+++ b/Reports/RStudio/client_side_latency_ListServicesInDetail.Rmd
@@ -7,47 +7,6 @@ readRenviron("~/.Renviron") # Make sure you have a APPMETRICS_CREDENTIALS=userna
 metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
 ```
 
-```{r fetchData0, echo=FALSE}
-application <- "CIAPILatencyCollector" 
-startTime <- "2012-09-17 13:00:00"
-endTime <- "2012-09-24 23:59:59"
-data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
-
-webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
-logdata <- read.table(tc <- textConnection(webpage), header=F, sep="\t", fill=TRUE, as.is=c(1,4)); 
-close(tc)
-colnames(logdata)=c('session','timestamp','key','value')
-```
-
-```{r groupSessionByNodes0, echo=FALSE}
-nodes1 <- logdata[logdata$"key" %in% c("Info_NodeName"), ]
-
-nodes1$nodeName = nodes1$value
-
-nodes1 <- subset(nodes1, select=c(-timestamp,-key,-value))
-```
-
-Latency between different endpoints
------------------------------------
-The following chart compares the latency of the Default IIS page from different 
-endpoints.  The IIS default page is assumed to be the fasted response the server can give, so this
-measures the latency due to the network:
-```{r network_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
-rpc <- logdata[logdata$"key" %in% c("Latency General.DefaultPage"), ]
-rpc$datetime <- strptime(rpc$timestamp, "%Y-%m-%d %H:%M:%S")
-rpc <- join(rpc, nodes1, by = "session", match = "first")
-
-d <- ggplot(rpc, aes(x=datetime, y=as.double(value)))
-d <- d + scale_y_continuous(limits=c(0.001, 1))
-d <- d + geom_hex()
-d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
-d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
-d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
-d <- d + facet_grid(nodeName ~ key)
-print(d)
-```
-As is expected, both the latency measures and the variability is higher for nodes geographically further away.
-
 ```{r fetchData, echo=FALSE}
 application <- "CIAPILatencyCollector.AllServiceMonitor.BuiltIn" #will switch to CIAPILatencyCollector once https://github.com/fandrei/AppMetrics/issues/101 has been resolved
 startTime <- "2012-09-17 13:00:00"
@@ -84,11 +43,10 @@ nodes$nodeName <- sub('46.137.47.103', 'AWS-EU-WEST-1B-79.125.25.36', nodes$node
 nodes <- subset(nodes, select=c(-timestamp,-key,-value))
 ```
 
-
 Latency between different services
 -----------------------------------
 The following graph compares the latency of different services for the same node:
-```{r service_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
+```{r service_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE, echo=FALSE}
 rpc2 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
                                     ,"Latency CIAPI.LogOut"
                                     ,"Latency CIAPI.ListSpreadMarkets"
@@ -116,23 +74,17 @@ d <- d + facet_grid(key ~ nodeName)
 d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
-There appears to have been some downtime on Sept 15th and 16th with the ListOpenPositions & ListTradeHistory services.
+Some of the services had sudden latency "step changes" during the week.
 
-Selective latencies in depth
+ListSpreadMarkets and ListNewsHeadlinesWithSource
 -----------------------------------
-The following graph compares:
+The following graph compares the services that experienced "step changes" during the week.
 
-1. GetClientAndTradingAccount - A "readonly" service query 
-1. ListTradeHistory - A complex "readonly" query
-1. Login - A simple "change server state" query
-1. Trade - A complex "change server state" query
+*NB:*  Note that this graph has a continuous scaled y axis, compared with the log_10 scaling of the first graph.
 
-```{r service_latency_plot_in_depth, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
-rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
-                                    ,"Latency CIAPI.Trade"
-                                    ,"Latency CIAPI.ListSpreadMarkets"
-                                    ,"Latency CIAPI.ListOpenPositions"         
-                                    ,"Latency CIAPI.ListTradeHistory"), ]
+```{r service_latency_plot_in_depth, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE, echo=FALSE}
+rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.ListNewsHeadlinesWithSource"
+                                    ,"Latency CIAPI.ListSpreadMarkets"), ]
 
 rpc3$datetime <- strptime(rpc3$timestamp, "%Y-%m-%d %H:%M:%S")
 rpc3$key <- sub('Latency CIAPI.', '',rpc3$key)
@@ -141,7 +93,7 @@ rpc3 <- rpc3[rpc3$nodeName %in% c("AWS-EU-WEST-1B-79.125.25.36"),]
 
 d <- ggplot(rpc3, aes(x=datetime, y=as.double(value)))
 d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
-d <- d + scale_y_log10() 
+d <- d + scale_y_continuous(limits=c(0.05, 0.5)) 
 d <- d + geom_hex()
 d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
 d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
@@ -151,8 +103,38 @@ d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```
 
-Performance has been largly consistent, with median Trade andLogin requests where processed in 100ms.
+ListSpreadMarkets exhibited large & sudden improvement in performance on Wed 19th Sept that disappeared just as quickly as it arose on Sun Sep 21st.  The only other service that exhibited the same pattern was the ListNewsHeadlinesWithSource service, although the improvements there were not as dramatic.
 
-Finally, we continue to see quite a few outliers for the Trade and Login services, with some requests taking up to 10 seconds to process. 
+ListTradeHistory, Login and Trade
+-----------------------------------
+The following graph compares the services that experienced "step changes" during the week:
+
+*NB:*  Note that this graph has a continuous scaled y axis, compared with the log_10 scaling of the first graph.
+
+```{r service_latency_plot_in_depth2, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE, echo=FALSE}
+rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.LogIn"
+                                    ,"Latency CIAPI.Trade"      
+                                    ,"Latency CIAPI.ListTradeHistory"), ]
+
+rpc3$datetime <- strptime(rpc3$timestamp, "%Y-%m-%d %H:%M:%S")
+rpc3$key <- sub('Latency CIAPI.', '',rpc3$key)
+rpc3 <- join(rpc3, nodes, by = "session", match = "first")
+rpc3 <- rpc3[rpc3$nodeName %in% c("AWS-EU-WEST-1B-79.125.25.36"),]
+
+d <- ggplot(rpc3, aes(x=datetime, y=as.double(value)))
+d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
+d <- d + scale_y_continuous(limits=c(0.05, 0.5)) 
+d <- d + geom_hex()
+d <- d + stat_quantile( quantiles = c(0.5, 0.98) ) 
+d <- d + geom_rug(aes(x=NULL, y=as.double(value)), col=rgb(.5,0,0, alpha=.05))
+d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
+d <- d + facet_grid(key ~ nodeName, scales="free_y")
+d <- d + opts(strip.text.y = theme_text( angle=0))
+print(d)
+```
+
+ListTradeHistory, Login and Trade all seemed to experience a performance degredation during the same period between Thurs 20 Sept and Sun Sept 23.
+
+
 
 

--- a/Reports/RStudio/client_side_latency_histograms.R
+++ b/Reports/RStudio/client_side_latency_histograms.R
@@ -1,0 +1,42 @@
+#Clean up source data
+logdata$datetime <- strptime(logdata$timestamp, "%Y-%m-%d %H:%M:%S")
+logdata$key <- sub('Latency CIAPI.', '',logdata$key)
+logdata <- join(logdata, nodes, by = "session", match = "first")
+logdata <- logdata[logdata$nodeName %in% c("AWS-EU-WEST-1B-79.125.25.36"),]
+
+#A normal distribution
+x <- seq(0, 0.6, length=1000)
+hx <- dnorm(x,mean=0.3,sd=0.1)
+plot(x,hx,type="l",lwd=2)
+
+# ListNewsHeadlines
+listNewsHeadlines <- logdata[logdata$"key" %in% c("ListNewsHeadlinesWithSource"), ]
+newsHist <- ggplot(listNewsHeadlines, aes(x=as.numeric(value)))
+newsHist <- newsHist + scale_x_continuous(limits=c(0.0, 0.6)) 
+newsHist <- newsHist + geom_histogram(binwidth = 0.005)
+print(newsHist)
+
+# ListSpreadMarkets
+listSpreadMarkets <- logdata[logdata$"key" %in% c("ListSpreadMarkets"), ]
+spreadHist <- ggplot(listSpreadMarkets, aes(x=as.numeric(value)))
+spreadHist <- spreadHist + scale_x_continuous(limits=c(0.0, 0.6)) 
+spreadHist <- spreadHist + geom_histogram(binwidth = 0.005)
+print(spreadHist)
+
+# All
+allRpc <- logdata[logdata$"key" %in% c("LogIn"
+                                     ,"ListSpreadMarkets"
+                                     ,"GetClientAndTradingAccount"     
+                                     ,"GetMarketInformation"
+                                     ,"GetPriceBars"
+                                     ,"ListOpenPositions"
+                                     ,"ListNewsHeadlinesWithSource"
+                                     ,"ListTradeHistory"
+                                     ,"Trade" ), ]
+all <- ggplot(allRpc, aes(x=as.numeric(value)))
+all <- all + scale_x_continuous(limits=c(0.0, 0.6)) 
+all <- all + geom_histogram(binwidth = 0.005)
+all <- all + facet_grid(key ~ nodeName, scales="free_y")
+print(all)
+
+

--- a/Reports/RStudio/client_side_request_count.R
+++ b/Reports/RStudio/client_side_request_count.R
@@ -1,0 +1,34 @@
+library("ggplot2")
+library("RCurl")
+library("plyr")
+library("scales")
+readRenviron("~/.Renviron") # Make sure you have a APPMETRICS_CREDENTIALS=username:password entry
+metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
+
+application <- "CIAPILatencyCollector" 
+startTime <- "2012-09-15 12:00:00"
+endTime <- "2012-10-10 23:59:59"
+data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
+
+webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
+logdata <- read.table(tc <- textConnection(webpage), header=F, sep="\t", fill=TRUE, as.is=c(1,4)); 
+close(tc)
+colnames(logdata)=c('session','timestamp','key','value')
+
+rpc3 <- logdata[logdata$"key" %in% c("Latency CIAPI.Trade"         
+                                     ,"Latency CIAPI.ListOpenPositions"), ]
+rpc3$datetime <- strptime(rpc3$timestamp, "%Y-%m-%d %H:%M:%S")
+rpc3$key <- sub('Latency CIAPI.', '',rpc3$key)
+
+d <- ggplot(rpc3, aes(x=datetime, y=as.double(value)))
+d <- d + ylab("Latency in seconds") + xlab("Measurement time (UTC)")
+d <- d + geom_point(alpha = 0.2)
+d <- d + scale_fill_gradient(low="grey", high="red") + theme_bw()
+d <- d + facet_grid(key ~ ., scales="free_y")
+d <- d + opts(strip.text.y = theme_text( angle=0))
+print(d)
+
+rpc4 <- logdata[logdata$"key" %in% c("Latency CIAPI.Trade"), ]
+rpc4$datetime <- strptime(rpc4$timestamp, "%Y-%m-%d %H:%M:%S")
+rpc4$key <- sub('Latency CIAPI.', '',rpc4$key)
+ggplot(rpc4, aes(x=datetime)) + geom_histogram(binwidth = 10000, colour="black", fill="white")

--- a/Reports/RStudio/latency_collector_resource_usage.Rmd
+++ b/Reports/RStudio/latency_collector_resource_usage.Rmd
@@ -1,0 +1,52 @@
+```{r init, echo=FALSE}
+library("ggplot2")
+library("RCurl")
+library("plyr")
+library("scales")
+readRenviron("~/.Renviron") # Make sure you have a APPMETRICS_CREDENTIALS=username:password entry
+metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
+```
+
+```{r fetchData, echo=FALSE}
+application <- "CIAPILatencyCollector" # note that https://github.com/fandrei/AppMetrics/issues/101 causes an extra 50ms delay to be introduced by the client side library.
+startTime <- "2012-08-20 00:00:00"
+endTime <- "2012-08-25 23:59:59"
+data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
+
+webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
+logdata <- read.table(tc <- textConnection(webpage), header=F, sep="\t", fill=TRUE, as.is=c(1,4)); 
+close(tc)
+colnames(logdata)=c('session','timestamp','key','value')
+```
+
+```{r groupSessionByNodes, echo=FALSE}
+# 46.137.47.103  => Production Ireland CIAPI Latency Collector node     (switched to 79.125.25.36  on 2012-09-03)
+# 175.41.155.112 => Production Singapore CIAPI Latency Collector node   (switched to 54.251.61.159 on 2012-09-03)
+
+nodes <- logdata[logdata$"key" %in% c("ClientIP"), ]
+nodes$nodeName = nodes$value
+nodes$nodeName <- sub('46.137.47.103', 'AWS_Ireland(46.137.47.103)',nodes$nodeName, fixed = TRUE)
+nodes$nodeName <- sub('175.41.155.112', 'AWS_Singapore(175.41.155.112)',nodes$nodeName, fixed = TRUE)
+nodes <- subset(nodes, select=c(-timestamp,-key,-value))
+```
+
+Resource usage on CIAPI Latency Collector nodes
+-----------------------------------
+```{r service_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
+rpc2 <- logdata[logdata$"key" %in% c("Client_PrivateMemorySize"
+                                    ,"System_AvailablePhysicalMemory"
+                                    ,"System_AvailableVirtualMemory"
+                                    ,"Client_PeriodProcessorUsage" ), ]
+
+rpc2$datetime <- strptime(rpc2$timestamp, "%Y-%m-%d %H:%M:%S")
+rpc2$key <- sub('Latency CIAPI.', '',rpc2$key)
+rpc2 <- join(rpc2, nodes, by = "session", match = "first")
+
+d <- ggplot(rpc2, aes(x=datetime, y=as.double(value)))
+d <- d + theme_bw()
+d <- d + geom_line()
+d <- d + xlab("Measurement time (UTC)")
+d <- d + facet_grid(key ~ nodeName, scales = "free_y")
+d <- d + opts(strip.text.y = theme_text( angle=0))
+print(d)
+```

--- a/Reports/RStudio/latency_collector_resource_usage.Rmd
+++ b/Reports/RStudio/latency_collector_resource_usage.Rmd
@@ -9,8 +9,8 @@ metrics_credentials <- Sys.getenv(c("APPMETRICS_CREDENTIALS"))
 
 ```{r fetchData, echo=FALSE}
 application <- "CIAPILatencyCollector" # note that https://github.com/fandrei/AppMetrics/issues/101 causes an extra 50ms delay to be introduced by the client side library.
-startTime <- "2012-08-20 00:00:00"
-endTime <- "2012-08-25 23:59:59"
+startTime <- "2012-10-08 00:00:00"
+endTime <- "2012-10-11 23:59:59"
 data_url <- URLencode(paste("http://metrics.cityindex.com/GetRecords.ashx?Application=",application,"&StartTime=",startTime,'&EndTime=',endTime, sep = ''))
 
 webpage <- getURL(data_url,userpwd=metrics_credentials, httpauth = 1L)
@@ -20,33 +20,31 @@ colnames(logdata)=c('session','timestamp','key','value')
 ```
 
 ```{r groupSessionByNodes, echo=FALSE}
-# 46.137.47.103  => Production Ireland CIAPI Latency Collector node     (switched to 79.125.25.36  on 2012-09-03)
-# 175.41.155.112 => Production Singapore CIAPI Latency Collector node   (switched to 54.251.61.159 on 2012-09-03)
-
-nodes <- logdata[logdata$"key" %in% c("ClientIP"), ]
+nodes <- logdata[logdata$"key" %in% c("Info_NodeName"), ]
 nodes$nodeName = nodes$value
-nodes$nodeName <- sub('46.137.47.103', 'AWS_Ireland(46.137.47.103)',nodes$nodeName, fixed = TRUE)
-nodes$nodeName <- sub('175.41.155.112', 'AWS_Singapore(175.41.155.112)',nodes$nodeName, fixed = TRUE)
 nodes <- subset(nodes, select=c(-timestamp,-key,-value))
 ```
 
 Resource usage on CIAPI Latency Collector nodes
 -----------------------------------
 ```{r service_latency_plot, fig.width=10, fig.height = 7, tidy=FALSE, warning=FALSE}
-rpc2 <- logdata[logdata$"key" %in% c("Client_PrivateMemorySize"
-                                    ,"System_AvailablePhysicalMemory"
-                                    ,"System_AvailableVirtualMemory"
-                                    ,"Client_PeriodProcessorUsage" ), ]
+rpc2 <- logdata[logdata$"key" %in% c("Client_PrivateMemorySize" ), ]
 
 rpc2$datetime <- strptime(rpc2$timestamp, "%Y-%m-%d %H:%M:%S")
 rpc2$key <- sub('Latency CIAPI.', '',rpc2$key)
 rpc2 <- join(rpc2, nodes, by = "session", match = "first")
 
+#rpc2 <- rpc2[rpc2$nodeName %in% c("AWS(Ireland)_eu-west-1b_46.137.187.155",
+#                                  "AWS(NorthCalifornia)_us-west-1b_184.169.142.250",
+#                                  "AWS(Tokyo)_ap-northeast-1b_54.248.116.221",
+#                                  "AWS(SaoPaolo)_sa-east-1b_177.71.182.25"
+#                                  ),]
+
 d <- ggplot(rpc2, aes(x=datetime, y=as.double(value)))
 d <- d + theme_bw()
 d <- d + geom_line()
 d <- d + xlab("Measurement time (UTC)")
-d <- d + facet_grid(key ~ nodeName, scales = "free_y")
+d <- d + facet_grid(. ~ key, scales = "free_y")
 d <- d + opts(strip.text.y = theme_text( angle=0))
 print(d)
 ```


### PR DESCRIPTION
We've been asked to do a weekly analysis of live performance via a blog post to the http://labs.cityindex.com/performance blog.

This should include:

(a) Graphs of the performance of each service during the week.
(b) Analysis of any unusual latencies.

To begin with, we'll do this manually; once we've figured out which bits are standard, we'll automate those.
