### PR TITLE
Stack overflow in unmanaged: IP: 0x5fad4c, fault addr: 0x7f7fc7a89b28

### DIFF
--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono.sln
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "issue138-StackOverflowException-on-Mono", "issue138-StackOverflowException-on-Mono\issue138-StackOverflowException-on-Mono.csproj", "{FA5AABB4-E49C-4F4D-AAA3-AB512F448BE1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FA5AABB4-E49C-4F4D-AAA3-AB512F448BE1}.Debug|x86.ActiveCfg = Debug|x86
+		{FA5AABB4-E49C-4F4D-AAA3-AB512F448BE1}.Debug|x86.Build.0 = Debug|x86
+		{FA5AABB4-E49C-4F4D-AAA3-AB512F448BE1}.Release|x86.ActiveCfg = Release|x86
+		{FA5AABB4-E49C-4F4D-AAA3-AB512F448BE1}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = issue138-StackOverflowException-on-Mono\issue138-StackOverflowException-on-Mono.csproj
+	EndGlobalSection
+EndGlobal

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/Program.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/Program.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.VisualBasic.Devices;
+
+namespace issue138StackOverflowExceptiononMono
+{
+	class MainClass
+	{
+		public static void Main (string[] args)
+		{
+			/* When run under Mono, generates evens like:
+			 * POST http://foo.com
+					AccessKey=accessKey
+					MessageAppKey=appKey
+					MessagesList=7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:02.9872070	System_OsName	Unix
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:02.9892350	System_OsVersion	Unix 12.4.0.0
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:02.9893300	System_ComputerName	maccy001
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:02.9893920	System_UserName	mrdavidlaing
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:02.9908230	System_ClrVersion	4.0.30319.17020
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:03.0028930	Exception	System.NotImplementedException: The requested feature is not implemented.\n  at Microsoft.VisualBasic.Devices.ComputerInfo.get_TotalPhysicalMemory () [0x00000] in /private/tmp/source/bockbuild-crypto-mono/profiles/mono-mac-xamarin/build-root/mono-mono-basic-6bb2ca6/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.Devices/ComputerInfo.vb:80 \n  at issue138StackOverflowExceptiononMono.Tracker.ReportSystemInfo () [0x000a0] in /Users/mrdavidlaing/Projects/fandrei/AppMetrics/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/Tracker.cs:312 
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:03.0029940	Client_WorkingSet	8
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:03.0039930	Client_PrivateMemorySize	10231566338
+				7ca6f023-f945-4052-a566-609aae8acde0	2013-06-27 17:10:03.0041890	Exception	System.NotImplementedException: The requested feature is not implemented.\n  at Microsoft.VisualBasic.Devices.ComputerInfo.get_AvailablePhysicalMemory () [0x00000] in /private/tmp/source/bockbuild-crypto-mono/profiles/mono-mac-xamarin/build-root/mono-mono-basic-6bb2ca6/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.Devices/ComputerInfo.vb:42 \n  at issue138StackOverflowExceptiononMono.Tracker.ReportPeriodicInfo () [0x00040] in /Users/mrdavidlaing/Projects/fandrei/AppMetrics/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/Tracker.cs:374 
+			 */
+			var tracker = Tracker.Create ("http://foo.com", "appKey", "accessKey");
+
+			/* No errors when run under Mono */
+//			var tracker = MonoCompatableTracker.Create ("http://foo.com", "appKey", "accessKey");
+
+			var watch = tracker.StartMeasure ();
+			tracker.EndMeasure (watch, "Dummy event");
+
+			watch = tracker.StartMeasure ();
+			tracker.EndMeasure (watch, "Dummy event 2");
+
+
+			// Note that HttpUtil has been customised to log messages to the console rather than make HttpRequests
+			tracker.FlushMessages ();
+
+			tracker.Dispose ();
+		}
+	}
+}

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/Properties/AssemblyInfo.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("issue138-StackOverflowException-on-Mono")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("mrdavidlaing")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/HttpUtil.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/HttpUtil.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace issue138StackOverflowExceptiononMono
+{
+	public static class HttpUtil
+	{
+		private const int DefaultTimeout = 100 * 1000;
+
+		public static string Request(string url, Dictionary<string, string> args = null, string method = "GET", 
+			int timeout = DefaultTimeout, ICredentials credentials = null)
+		{
+			var buf = new StringBuilder();
+			if (args != null)
+			{
+				foreach (var val in args)
+				{
+					buf.AppendFormat("{0}={1}&", Uri.EscapeDataString(val.Key), Uri.EscapeDataString(val.Value));
+				}
+			}
+
+			if (method == "GET" && buf.Length > 0)
+			{
+				if (url.Contains("?"))
+					url += "&";
+				else
+					url += "?";
+				url += buf;
+			}
+
+//			var request = (HttpWebRequest)WebRequest.Create(url);
+//			request.Method = method;
+//			request.Timeout = timeout;
+//			request.ReadWriteTimeout = request.Timeout;
+//			request.Credentials = credentials;
+//
+//			if (method == "GET")
+//			{
+//				request.ContentType = "text/plain; encoding='utf-8'";
+//			}
+//			else if (method == "POST")
+//			{
+//				request.ContentType = "application/x-www-form-urlencoded; encoding='utf-8'";
+//
+//				using (var stream = request.GetRequestStream())
+//				{
+//					using (var writer = new StreamWriter(stream)) // UTF8 without BOM
+//					{
+//						writer.Write(buf.ToString());
+//					}
+//				}
+//			}
+
+			Console.WriteLine ("{0} {1}", method, url);
+
+			if (args != null)
+			{
+				foreach (var val in args)
+				{
+					Console.WriteLine("\t{0}={1}", val.Key, val.Value);
+				}
+			}
+
+//			using (var response = request.GetResponse())
+//			using (var responseStream = response.GetResponseStream())
+//			using (var reader = new StreamReader(responseStream, Encoding.UTF8))
+//			{
+//				return reader.ReadToEnd();
+//			}
+			return "OK";
+		}
+
+		public static string Request(string url, ICredentials credentials, Dictionary<string, string> args = null, int timeout = DefaultTimeout)
+		{
+			return Request(url, args, "GET", timeout, credentials);
+		}
+	}
+}

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/MessageInfo.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/MessageInfo.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace issue138StackOverflowExceptiononMono
+{
+	class MessageInfo
+	{
+		public string Name;
+		public string Value;
+		public string SessionId;
+		public DateTime Time;
+		public MessagePriority Priority;
+
+		public override string ToString()
+		{
+			var res = string.Format("[{0} {1}] {2}: {3}", Time, Priority, Name, Value);
+			return res;
+		}
+	}
+}

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/MonoCompatableTracker.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/MonoCompatableTracker.cs
@@ -1,0 +1,429 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+using Microsoft.VisualBasic.Devices;
+
+namespace issue138StackOverflowExceptiononMono
+{
+	public class MonoCompatableTracker : TrackerBase
+	{
+		public static MonoCompatableTracker Create(string url, string applicationKey, string accessKey)
+		{
+			lock (Sync)
+			{
+				if (_terminated)
+					throw new InvalidOperationException();
+
+				var found = Sessions.Where(
+					session => !session._disposed && session.Url == url && session.ApplicationKey == applicationKey);
+				if (found.FirstOrDefault() != null)
+					return found.First();
+				var res = new MonoCompatableTracker(url, applicationKey, accessKey);
+				return res;
+			}
+		}
+
+		private MonoCompatableTracker(string url, string applicationKey, string accessKey)
+		{
+			if (string.IsNullOrEmpty(url))
+				throw new ArgumentNullException();
+			Url = url;
+
+			if (string.IsNullOrEmpty(applicationKey))
+				throw new ArgumentNullException();
+			ApplicationKey = applicationKey;
+
+			AccessKey = accessKey;
+
+			SessionId = Guid.NewGuid().ToString();
+
+			lock (Sync)
+			{
+				Sessions.Add(this);
+			}
+			ReportPeriodicInfo();
+		}
+
+		public override void Dispose()
+		{
+			Log("SessionFinished", null, MessagePriority.High);
+			_disposed = true;
+		}
+
+		private volatile bool _disposed;
+
+		static MonoCompatableTracker()
+		{
+			lock (Sync)
+			{
+				_lastSentPeriodic = DateTime.UtcNow;
+				LoggingThread.Name = "AppMetrics_MessageSending";
+				LoggingThread.Start();
+			}
+		}
+
+		public static void Terminate(bool waitAll = false)
+		{
+			try
+			{
+				lock (Sync)
+				{
+					foreach (var session in Sessions)
+					{
+						session.Dispose();
+					}
+				}
+
+				_terminated = true;
+				var period = waitAll ? Timeout.Infinite : 5 * 1000;
+				LoggingThread.Join(period);
+				LoggingThread.Abort();
+
+				lock (Sync)
+				{
+					Sessions.Clear();
+				}
+			}
+			catch (Exception exc)
+			{
+				Trace.WriteLine(exc);
+			}
+		}
+
+		public override void FlushMessages()
+		{
+			SendMessages();
+		}
+
+		public override void Log(string name, string val, MessagePriority priority = MessagePriority.Low)
+		{
+			lock (Sync)
+			{
+				try
+				{
+					ReportSystemInfo();
+				}
+				catch (Exception exc)
+				{
+					Log(exc);
+				}
+
+				if (_messages.Count >= MaxMessagesCount)
+				{
+					_messages.RemoveAll(message => message.Priority == MessagePriority.Low);
+
+					AddMessage(WarningName, "Message queue overflow. Some messages are skipped.", MessagePriority.High);
+					if (_messages.Count >= MaxMessagesCount) // too much high-priority messages
+					{
+						_messages.Clear();
+						AddMessage(ErrorName, "Critical message queue overflow. All messages are removed.", MessagePriority.High);
+					}
+				}
+
+				AddMessage(name, val, priority);
+			}
+		}
+
+		private const string WarningName = "AppMetrics.Warning";
+		private const string ErrorName = "AppMetrics.Error";
+
+		private void AddMessage(string name, string val, MessagePriority priority)
+		{
+			if (_disposed || _terminated)
+			{
+				Trace.WriteLine("WARNING.AppMetrics.Client: message ignored");
+				return;
+			}
+
+			var valText = Escape(val ?? "");
+
+			lock (Sync)
+			{
+				_messages.Add(
+					new MessageInfo
+					{
+					Name = name,
+					Value = valText,
+					SessionId = SessionId,
+					Time = DateTime.UtcNow,
+					Priority = priority
+				});
+			}
+		}
+
+		static void LoggingThreadEntry()
+		{
+			try
+			{
+				while (!_terminated)
+				{
+					SendAllMessages();
+					Thread.Sleep(SendingPeriod);
+				}
+
+				SendAllMessages();
+			}
+			catch (ThreadInterruptedException)
+			{ }
+			catch (ThreadAbortException)
+			{ }
+			catch (Exception exc)
+			{
+				Trace.WriteLine(exc);
+			}
+		}
+
+		private static void SendAllMessages()
+		{
+			MonoCompatableTracker[] sessions;
+			lock (Sync)
+			{
+				sessions = Sessions.ToArray();
+			}
+
+			foreach (var session in sessions)
+			{
+				session.SendMessages();
+
+				if (session._disposed)
+				{
+					lock (Sync)
+					{
+						Sessions.Remove(session);
+					}
+				}
+			}
+		}
+
+		private void SendMessages()
+		{
+			lock (SendingSync)
+			{
+				try
+				{
+					ReportPeriodicInfoAllSessions();
+
+					while (true)
+					{
+						string packet = null;
+						lock (Sync)
+						{
+							if (_packet.Length == 0)
+							{
+								if (_messages.Count == 0)
+									return;
+								BuildPacket();
+							}
+
+							packet = _packet.ToString();
+						}
+
+						SendPacket(Url, AccessKey, ApplicationKey, packet);
+
+						lock (Sync)
+						{
+							_packet.Clear(); // clear packet only if succeeded
+						}
+					}
+				}
+				catch (ThreadInterruptedException)
+				{
+				}
+				catch (Exception exc)
+				{
+					Log("Exception", exc.ToString());
+				}
+			}
+		}
+
+		private void BuildPacket()
+		{
+			int i = 0;
+			for (; i < _messages.Count; i++)
+			{
+				var message = _messages[i];
+				var cur = string.Format("{0}\t{1}\t{2}\t{3}\r\n", message.SessionId,
+				                        message.Time.ToString("yyyy-MM-dd HH:mm:ss.fffffff"), message.Name, message.Value);
+
+				if (_packet.Length + cur.Length > _packet.Capacity)
+					break;
+				_packet.Append(cur);
+			}
+
+			var messagesSent = i;
+			_messages.RemoveRange(0, messagesSent);
+		}
+
+		static void SendPacket(string url, string accessKey, string appKey, string packet)
+		{
+			var args = new Dictionary<string, string>()
+			{
+				{ "AccessKey", accessKey },
+				{ "MessageAppKey", appKey },
+				{ "MessagesList", packet }, 
+			};
+
+			var responseText = HttpUtil.Request(url, args, "POST");
+
+			CountNewRequest();
+			if (!string.IsNullOrEmpty(responseText))
+				throw new ApplicationException(responseText);
+		}
+
+		static void CountNewRequest()
+		{
+			Interlocked.Increment(ref _requestsSent);
+		}
+
+		public static long GetServedRequestsCount()
+		{
+			var res = Interlocked.Read(ref _requestsSent);
+			return res;
+		}
+
+		private bool _systemInfoIsReported;
+
+		void ReportSystemInfo()
+		{
+			lock (Sync)
+			{
+				if (_systemInfoIsReported)
+					return;
+				_systemInfoIsReported = true;
+			}
+
+			try
+			{
+				var computerInfo = new ComputerInfo();
+
+				Log("System_OsName", computerInfo.OSFullName);
+				Log("System_OsVersion", Environment.OSVersion.VersionString);
+
+				Log("System_ComputerName", Environment.MachineName);
+				Log("System_UserName", Environment.UserName);
+
+				Log("System_ClrVersion", Environment.Version.ToString());
+
+				//Log("System_PhysicalMemory", ToMegabytes(computerInfo.TotalPhysicalMemory));
+				//Log("System_VirtualMemory", ToMegabytes(computerInfo.TotalVirtualMemory));
+
+				Log("System_CurrentCulture", Thread.CurrentThread.CurrentCulture.Name);
+				Log("System_CurrentUiCulture", Thread.CurrentThread.CurrentUICulture.Name);
+
+				Log("System_SystemDefaultEncoding", Encoding.Default.WebName);
+
+				Log("System_CalendarType", CultureInfo.CurrentCulture.Calendar.GetType().Name);
+
+				Log("System_NumberDecimalSeparator", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+
+				var timeZone = TimeZone.CurrentTimeZone;
+				Log("System_TimeZone", timeZone.StandardName);
+
+				var offset = timeZone.GetUtcOffset(DateTime.Now);
+				Log("System_TimeZoneOffset", offset.TotalHours);
+
+				var processFile = Process.GetCurrentProcess().MainModule.FileName;
+				Log("Client_ProcessName", processFile);
+
+//				var processVersion = FileVersionInfo.GetVersionInfo(processFile).FileVersion;
+//				Log("Client_ProcessVersion", processVersion);
+
+				var curAssembly = GetType().Assembly;
+				Log("Client_AppMetricsVersion", curAssembly.FullName);
+			}
+			catch (Exception exc)
+			{
+				Log(exc);
+			}
+		}
+
+		static void ReportPeriodicInfoAllSessions()
+		{
+			lock (Sync)
+			{
+				if (DateTime.UtcNow - _lastSentPeriodic < PeriodicTime)
+					return;
+
+				foreach (var session in Sessions)
+				{
+					session.ReportPeriodicInfo();
+				}
+				_lastSentPeriodic = DateTime.UtcNow;
+			}
+		}
+
+		private void ReportPeriodicInfo()
+		{
+			try
+			{
+				var curProcess = Process.GetCurrentProcess();
+
+				var workingSet = ToMegabytes((ulong)curProcess.WorkingSet64);
+				Log("Client_WorkingSet", workingSet);
+
+				var privateMemorySize = ToMegabytes((ulong)curProcess.PrivateMemorySize64);
+				Log("Client_PrivateMemorySize", privateMemorySize);
+
+				var computerInfo = new ComputerInfo();
+
+//				Log("System_AvailablePhysicalMemory", ToMegabytes(computerInfo.AvailablePhysicalMemory));
+//				Log("System_AvailableVirtualMemory", ToMegabytes(computerInfo.AvailableVirtualMemory));
+
+				var processorSecondsUsed = curProcess.TotalProcessorTime.TotalSeconds;
+				if (_lastProcessorTimeUsage != 0)
+				{
+					var secondsPassed = (DateTime.UtcNow - _lastSentPeriodic).TotalSeconds;
+					var averageProcessorUsage = ((processorSecondsUsed - _lastProcessorTimeUsage) / secondsPassed) * 100;
+					Log("Client_PeriodProcessorUsage", averageProcessorUsage);
+				}
+				_lastProcessorTimeUsage = processorSecondsUsed;
+			}
+			catch (Exception exc)
+			{
+				Log(exc);
+			}
+		}
+
+		static ulong ToMegabytes(ulong val)
+		{
+			return val / (1024 * 1024);
+		}
+
+		static string Escape(string val)
+		{
+			var res = val.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+			return res;
+		}
+
+		public string Url { get; private set; }
+		public string ApplicationKey { get; private set; }
+		public string SessionId { get; private set; }
+		public string AccessKey { get; private set; }
+
+		private static readonly object Sync = new object();
+		private static readonly object SendingSync = new object();
+
+		private readonly List<MessageInfo> _messages = new List<MessageInfo>(MaxMessagesCount);
+		private readonly StringBuilder _packet = new StringBuilder(MaxPacketSize);
+
+		private static readonly HashSet<MonoCompatableTracker> Sessions = new HashSet<MonoCompatableTracker>();
+		private static readonly Thread LoggingThread = new Thread(LoggingThreadEntry);
+
+		private const int MaxMessagesCount = 4096;
+		private const int MaxPacketSize = 1024 * 16;
+		private static readonly TimeSpan SendingPeriod = TimeSpan.FromSeconds(0.5);
+
+		private static DateTime _lastSentPeriodic;
+		private static readonly TimeSpan PeriodicTime = TimeSpan.FromMinutes(10);
+
+		private static double _lastProcessorTimeUsage;
+
+		private static long _requestsSent;
+		private static volatile bool _terminated;
+	}
+}

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/Tracker.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/Tracker.cs
@@ -1,0 +1,429 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+using Microsoft.VisualBasic.Devices;
+
+namespace issue138StackOverflowExceptiononMono
+{
+	public class Tracker : TrackerBase
+	{
+		public static Tracker Create(string url, string applicationKey, string accessKey)
+		{
+			lock (Sync)
+			{
+				if (_terminated)
+					throw new InvalidOperationException();
+
+				var found = Sessions.Where(
+					session => !session._disposed && session.Url == url && session.ApplicationKey == applicationKey);
+				if (found.FirstOrDefault() != null)
+					return found.First();
+				var res = new Tracker(url, applicationKey, accessKey);
+				return res;
+			}
+		}
+
+		private Tracker(string url, string applicationKey, string accessKey)
+		{
+			if (string.IsNullOrEmpty(url))
+				throw new ArgumentNullException();
+			Url = url;
+
+			if (string.IsNullOrEmpty(applicationKey))
+				throw new ArgumentNullException();
+			ApplicationKey = applicationKey;
+
+			AccessKey = accessKey;
+
+			SessionId = Guid.NewGuid().ToString();
+
+			lock (Sync)
+			{
+				Sessions.Add(this);
+			}
+			ReportPeriodicInfo();
+		}
+
+		public override void Dispose()
+		{
+			Log("SessionFinished", null, MessagePriority.High);
+			_disposed = true;
+		}
+
+		private volatile bool _disposed;
+
+		static Tracker()
+		{
+			lock (Sync)
+			{
+				_lastSentPeriodic = DateTime.UtcNow;
+				LoggingThread.Name = "AppMetrics_MessageSending";
+				LoggingThread.Start();
+			}
+		}
+
+		public static void Terminate(bool waitAll = false)
+		{
+			try
+			{
+				lock (Sync)
+				{
+					foreach (var session in Sessions)
+					{
+						session.Dispose();
+					}
+				}
+
+				_terminated = true;
+				var period = waitAll ? Timeout.Infinite : 5 * 1000;
+				LoggingThread.Join(period);
+				LoggingThread.Abort();
+
+				lock (Sync)
+				{
+					Sessions.Clear();
+				}
+			}
+			catch (Exception exc)
+			{
+				Trace.WriteLine(exc);
+			}
+		}
+
+		public override void FlushMessages()
+		{
+			SendMessages();
+		}
+
+		public override void Log(string name, string val, MessagePriority priority = MessagePriority.Low)
+		{
+			lock (Sync)
+			{
+				try
+				{
+					ReportSystemInfo();
+				}
+				catch (Exception exc)
+				{
+					Log(exc);
+				}
+
+				if (_messages.Count >= MaxMessagesCount)
+				{
+					_messages.RemoveAll(message => message.Priority == MessagePriority.Low);
+
+					AddMessage(WarningName, "Message queue overflow. Some messages are skipped.", MessagePriority.High);
+					if (_messages.Count >= MaxMessagesCount) // too much high-priority messages
+					{
+						_messages.Clear();
+						AddMessage(ErrorName, "Critical message queue overflow. All messages are removed.", MessagePriority.High);
+					}
+				}
+
+				AddMessage(name, val, priority);
+			}
+		}
+
+		private const string WarningName = "AppMetrics.Warning";
+		private const string ErrorName = "AppMetrics.Error";
+
+		private void AddMessage(string name, string val, MessagePriority priority)
+		{
+			if (_disposed || _terminated)
+			{
+				Trace.WriteLine("WARNING.AppMetrics.Client: message ignored");
+				return;
+			}
+
+			var valText = Escape(val ?? "");
+
+			lock (Sync)
+			{
+				_messages.Add(
+					new MessageInfo
+					{
+					Name = name,
+					Value = valText,
+					SessionId = SessionId,
+					Time = DateTime.UtcNow,
+					Priority = priority
+				});
+			}
+		}
+
+		static void LoggingThreadEntry()
+		{
+			try
+			{
+				while (!_terminated)
+				{
+					SendAllMessages();
+					Thread.Sleep(SendingPeriod);
+				}
+
+				SendAllMessages();
+			}
+			catch (ThreadInterruptedException)
+			{ }
+			catch (ThreadAbortException)
+			{ }
+			catch (Exception exc)
+			{
+				Trace.WriteLine(exc);
+			}
+		}
+
+		private static void SendAllMessages()
+		{
+			Tracker[] sessions;
+			lock (Sync)
+			{
+				sessions = Sessions.ToArray();
+			}
+
+			foreach (var session in sessions)
+			{
+				session.SendMessages();
+
+				if (session._disposed)
+				{
+					lock (Sync)
+					{
+						Sessions.Remove(session);
+					}
+				}
+			}
+		}
+
+		private void SendMessages()
+		{
+			lock (SendingSync)
+			{
+				try
+				{
+					ReportPeriodicInfoAllSessions();
+
+					while (true)
+					{
+						string packet = null;
+						lock (Sync)
+						{
+							if (_packet.Length == 0)
+							{
+								if (_messages.Count == 0)
+									return;
+								BuildPacket();
+							}
+
+							packet = _packet.ToString();
+						}
+
+						SendPacket(Url, AccessKey, ApplicationKey, packet);
+
+						lock (Sync)
+						{
+							_packet.Clear(); // clear packet only if succeeded
+						}
+					}
+				}
+				catch (ThreadInterruptedException)
+				{
+				}
+				catch (Exception exc)
+				{
+					Log("Exception", exc.ToString());
+				}
+			}
+		}
+
+		private void BuildPacket()
+		{
+			int i = 0;
+			for (; i < _messages.Count; i++)
+			{
+				var message = _messages[i];
+				var cur = string.Format("{0}\t{1}\t{2}\t{3}\r\n", message.SessionId,
+				                        message.Time.ToString("yyyy-MM-dd HH:mm:ss.fffffff"), message.Name, message.Value);
+
+				if (_packet.Length + cur.Length > _packet.Capacity)
+					break;
+				_packet.Append(cur);
+			}
+
+			var messagesSent = i;
+			_messages.RemoveRange(0, messagesSent);
+		}
+
+		static void SendPacket(string url, string accessKey, string appKey, string packet)
+		{
+			var args = new Dictionary<string, string>()
+			{
+				{ "AccessKey", accessKey },
+				{ "MessageAppKey", appKey },
+				{ "MessagesList", packet }, 
+			};
+
+			var responseText = HttpUtil.Request(url, args, "POST");
+
+			CountNewRequest();
+			if (!string.IsNullOrEmpty(responseText))
+				throw new ApplicationException(responseText);
+		}
+
+		static void CountNewRequest()
+		{
+			Interlocked.Increment(ref _requestsSent);
+		}
+
+		public static long GetServedRequestsCount()
+		{
+			var res = Interlocked.Read(ref _requestsSent);
+			return res;
+		}
+
+		private bool _systemInfoIsReported;
+
+		void ReportSystemInfo()
+		{
+			lock (Sync)
+			{
+				if (_systemInfoIsReported)
+					return;
+				_systemInfoIsReported = true;
+			}
+
+			try
+			{
+				var computerInfo = new ComputerInfo();
+
+				Log("System_OsName", computerInfo.OSFullName);
+				Log("System_OsVersion", Environment.OSVersion.VersionString);
+
+				Log("System_ComputerName", Environment.MachineName);
+				Log("System_UserName", Environment.UserName);
+
+				Log("System_ClrVersion", Environment.Version.ToString());
+
+				Log("System_PhysicalMemory", ToMegabytes(computerInfo.TotalPhysicalMemory));
+				Log("System_VirtualMemory", ToMegabytes(computerInfo.TotalVirtualMemory));
+
+				Log("System_CurrentCulture", Thread.CurrentThread.CurrentCulture.Name);
+				Log("System_CurrentUiCulture", Thread.CurrentThread.CurrentUICulture.Name);
+
+				Log("System_SystemDefaultEncoding", Encoding.Default.WebName);
+
+				Log("System_CalendarType", CultureInfo.CurrentCulture.Calendar.GetType().Name);
+
+				Log("System_NumberDecimalSeparator", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+
+				var timeZone = TimeZone.CurrentTimeZone;
+				Log("System_TimeZone", timeZone.StandardName);
+
+				var offset = timeZone.GetUtcOffset(DateTime.Now);
+				Log("System_TimeZoneOffset", offset.TotalHours);
+
+				var processFile = Process.GetCurrentProcess().MainModule.FileName;
+				Log("Client_ProcessName", processFile);
+
+				var processVersion = FileVersionInfo.GetVersionInfo(processFile).FileVersion;
+				Log("Client_ProcessVersion", processVersion);
+
+				var curAssembly = GetType().Assembly;
+				Log("Client_AppMetricsVersion", curAssembly.FullName);
+			}
+			catch (Exception exc)
+			{
+				Log(exc);
+			}
+		}
+
+		static void ReportPeriodicInfoAllSessions()
+		{
+			lock (Sync)
+			{
+				if (DateTime.UtcNow - _lastSentPeriodic < PeriodicTime)
+					return;
+
+				foreach (var session in Sessions)
+				{
+					session.ReportPeriodicInfo();
+				}
+				_lastSentPeriodic = DateTime.UtcNow;
+			}
+		}
+
+		private void ReportPeriodicInfo()
+		{
+			try
+			{
+				var curProcess = Process.GetCurrentProcess();
+
+				var workingSet = ToMegabytes((ulong)curProcess.WorkingSet64);
+				Log("Client_WorkingSet", workingSet);
+
+				var privateMemorySize = ToMegabytes((ulong)curProcess.PrivateMemorySize64);
+				Log("Client_PrivateMemorySize", privateMemorySize);
+
+				var computerInfo = new ComputerInfo();
+
+				Log("System_AvailablePhysicalMemory", ToMegabytes(computerInfo.AvailablePhysicalMemory));
+				Log("System_AvailableVirtualMemory", ToMegabytes(computerInfo.AvailableVirtualMemory));
+
+				var processorSecondsUsed = curProcess.TotalProcessorTime.TotalSeconds;
+				if (_lastProcessorTimeUsage != 0)
+				{
+					var secondsPassed = (DateTime.UtcNow - _lastSentPeriodic).TotalSeconds;
+					var averageProcessorUsage = ((processorSecondsUsed - _lastProcessorTimeUsage) / secondsPassed) * 100;
+					Log("Client_PeriodProcessorUsage", averageProcessorUsage);
+				}
+				_lastProcessorTimeUsage = processorSecondsUsed;
+			}
+			catch (Exception exc)
+			{
+				Log(exc);
+			}
+		}
+
+		static ulong ToMegabytes(ulong val)
+		{
+			return val / (1024 * 1024);
+		}
+
+		static string Escape(string val)
+		{
+			var res = val.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+			return res;
+		}
+
+		public string Url { get; private set; }
+		public string ApplicationKey { get; private set; }
+		public string SessionId { get; private set; }
+		public string AccessKey { get; private set; }
+
+		private static readonly object Sync = new object();
+		private static readonly object SendingSync = new object();
+
+		private readonly List<MessageInfo> _messages = new List<MessageInfo>(MaxMessagesCount);
+		private readonly StringBuilder _packet = new StringBuilder(MaxPacketSize);
+
+		private static readonly HashSet<Tracker> Sessions = new HashSet<Tracker>();
+		private static readonly Thread LoggingThread = new Thread(LoggingThreadEntry);
+
+		private const int MaxMessagesCount = 4096;
+		private const int MaxPacketSize = 1024 * 16;
+		private static readonly TimeSpan SendingPeriod = TimeSpan.FromSeconds(0.5);
+
+		private static DateTime _lastSentPeriodic;
+		private static readonly TimeSpan PeriodicTime = TimeSpan.FromMinutes(10);
+
+		private static double _lastProcessorTimeUsage;
+
+		private static long _requestsSent;
+		private static volatile bool _terminated;
+	}
+}

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/TrackerBase.cs
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/SimulatedTracker/TrackerBase.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace issue138StackOverflowExceptiononMono
+{
+	public enum MessagePriority { Low = 0, High }
+
+	public abstract class TrackerBase : IDisposable
+	{
+		public abstract void Dispose();
+
+		public abstract void Log(string name, string val, MessagePriority priority = MessagePriority.Low);
+		public abstract void FlushMessages();
+
+		public void Log(Exception exc)
+		{
+			Log("Exception", exc.ToString(), MessagePriority.High);
+		}
+
+		public void Log(string name, object val, MessagePriority priority = MessagePriority.Low)
+		{
+			Log(name, val.ToString(), priority);
+		}
+
+		public void Log(string name, double val, MessagePriority priority = MessagePriority.Low)
+		{
+			Log(name, val.ToString(CultureInfo.InvariantCulture), priority);
+		}
+
+		public void Log(string name, float val, MessagePriority priority = MessagePriority.Low)
+		{
+			Log(name, val.ToString(CultureInfo.InvariantCulture), priority);
+		}
+
+		public void Log(string name, decimal val, MessagePriority priority = MessagePriority.Low)
+		{
+			Log(name, val.ToString(CultureInfo.InvariantCulture), priority);
+		}
+
+		public void Log(string name, long val, MessagePriority priority = MessagePriority.Low)
+		{
+			Log(name, val.ToString(CultureInfo.InvariantCulture), priority);
+		}
+
+		public void Log(string name, ulong val, MessagePriority priority = MessagePriority.Low)
+		{
+			Log(name, val.ToString(CultureInfo.InvariantCulture), priority);
+		}
+
+		public void LogFormat(string name, MessagePriority priority, string format, params object[] args)
+		{
+			var text = string.Format(CultureInfo.InvariantCulture, format, args);
+			Log(name, text, priority);
+		}
+
+		public void LogFormat(string name, string format, params object[] args)
+		{
+			LogFormat(name, MessagePriority.Low, format, args);
+		}
+
+		public Stopwatch StartMeasure()
+		{
+			return Stopwatch.StartNew();
+		}
+
+		public void EndMeasure(Stopwatch watch, string label)
+		{
+			var diff = watch.Elapsed;
+			watch.Stop();
+
+			LogLatency(label, diff.TotalSeconds);
+		}
+
+		public void LogLatency(string label, double value)
+		{
+			Log("Latency " + label, value);
+		}
+	}
+}

--- a/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono.csproj
+++ b/samples/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono/issue138-StackOverflowException-on-Mono.csproj
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{FA5AABB4-E49C-4F4D-AAA3-AB512F448BE1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>issue138StackOverflowExceptiononMono</RootNamespace>
+    <AssemblyName>ConsoleRunner</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <OutputPath>..\app\bin</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\app\bin</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.VisualBasic">
+      <private>True</private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimulatedTracker\Tracker.cs" />
+    <Compile Include="SimulatedTracker\TrackerBase.cs" />
+    <Compile Include="SimulatedTracker\HttpUtil.cs" />
+    <Compile Include="SimulatedTracker\MessageInfo.cs" />
+    <Compile Include="SimulatedTracker\MonoCompatableTracker.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Folder Include="SimulatedTracker\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\stackato.yml">
+      <Link>stackato.yml</Link>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/issue138-StackOverflowException-on-Mono/stackato.yml
+++ b/samples/issue138-StackOverflowException-on-Mono/stackato.yml
@@ -1,0 +1,11 @@
+name: issue138-StackOverflowException
+instances: 1
+framework:
+  type: buildpack
+env:
+  BUILDPACK_URL: git://github.com/mrdavidlaing/stackato-buildpack-mono.git
+mem: 128
+app-dir: app
+ignores: ["config", "logs", "runtimes"]
+services:
+    ${name}-cache: filesystem


### PR DESCRIPTION
From cityindex/csharp-bot-development-flow#8

Running an app under mono 3.0.10 on Ubuntu 12.04 using Tracker functionality from  AppMetrics.Client.dll fails with the following

```
2013-06-26T17:26:27+0000 app.0: Stack overflow in unmanaged: IP: 0x5fad4c, fault addr: 0x7f7fc7a89cc8
2013-06-26T17:26:37+0000 app.0: Stacktrace:
2013-06-26T17:26:37+0000 app.0:
2013-06-26T17:26:37+0000 app.0:
2013-06-26T17:26:37+0000 app.0: Native stacktrace:
2013-06-26T17:26:37+0000 app.0:
2013-06-26T17:26:37+0000 app.0: Stack overflow in unmanaged: IP: 0x5fad4c, fault addr: 0x7f7fc7a89c78
2013-06-26T17:26:37+0000 app.0:         /app/app/runtimes/mono/bin/mono() [0x4a27fd]
2013-06-26T17:26:37+0000 app.0:         /app/app/runtimes/mono/bin/mono() [0x4f718f]
2013-06-26T17:26:37+0000 app.0:         /app/app/runtimes/mono/bin/mono() [0x41ce87]
2013-06-26T17:26:37+0000 app.0:         /lib/x86_64-linux-gnu/libpthread.so.0(+0xfcb0) [0x7f7fcf302cb0]
2013-06-26T17:26:37+0000 app.0:         [0x7f7fc7a7fce0]
2013-06-26T17:26:37+0000 app.0:
2013-06-26T17:26:37+0000 app.0: Debug info from gdb:
```

I'll attach a test case showing which functionality causes the issue shortly.
